### PR TITLE
Removed caching of fixture preview

### DIFF
--- a/lib/email_preview/fixture.rb
+++ b/lib/email_preview/fixture.rb
@@ -9,7 +9,7 @@ module EmailPreview
       self.callback = block
     end
     def preview
-      @mail ||= self.callback.call
+      self.callback.call
     end
     def preview_with_transaction
       return preview_without_transaction unless EmailPreview.transactional?

--- a/lib/email_preview/fixture.rb
+++ b/lib/email_preview/fixture.rb
@@ -11,6 +11,7 @@ module EmailPreview
     def preview
       self.callback.call
     end
+    alias :preview_without_transaction :preview
     def preview_with_transaction
       return preview_without_transaction unless EmailPreview.transactional?
       mail = nil

--- a/lib/email_preview/fixture.rb
+++ b/lib/email_preview/fixture.rb
@@ -11,7 +11,6 @@ module EmailPreview
     def preview
       self.callback.call
     end
-    alias :preview_without_transaction :preview
     def preview_with_transaction
       return preview_without_transaction unless EmailPreview.transactional?
       mail = nil
@@ -21,6 +20,7 @@ module EmailPreview
       end
       mail
     end
+    alias_method_chain :preview, :transaction
   end
 
 end


### PR DESCRIPTION
By caching the result of EmailPreview::Fixture#preview, it requires the developer to restart the rails application every time they modify the e-mail template.

Also adds a missing method alias_method_chain in order for EmailPreview::Fixture#preview_with_transaction to work
