### PR TITLE
add EmailPreview.delivery_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ To make it available to other environments use:
 EmailPreview.allowed_environments << 'production'
 ```
 
+### (optional) set a different delivery method in development
+
+By default emails are delivered with the delivery_method configured for your application.
+You can override this so that if you use :test for development you can still deliver mails
+when you use the send test email form.
+
+```ruby
+# config/environments/development.rb
+EmailPreview.delivery_method = :smtp # or :sendmail, etc
+ActionMailer::Base.smtp_settings = {:port => 12345} # additional configuration is optional
+```
 
 ## Contributing 
 

--- a/app/controllers/email_preview_controller.rb
+++ b/app/controllers/email_preview_controller.rb
@@ -7,6 +7,9 @@ class EmailPreviewController < ApplicationController
 
   def deliver
     @mail.to params[:to]
+    if EmailPreview.delivery_method
+      @mail.delivery_method(ActionMailer::Base.delivery_methods[EmailPreview.delivery_method], ActionMailer::Base.send("#{EmailPreview.delivery_method}_settings"))
+    end
     @mail.deliver
     redirect_to details_email_preview_path(params[:id])
   end

--- a/lib/email_preview.rb
+++ b/lib/email_preview.rb
@@ -9,6 +9,7 @@ module EmailPreview
     attr_accessor :transactional
     attr_accessor :logger
     attr_accessor :before_preview_hook
+    attr_accessor :delivery_method
 
     def register(description, options={}, &block)
       fixture = EmailPreview::Fixture.new(description, options, &block)


### PR DESCRIPTION
set EmailPreview.delivery_method to deliver test mails with a different method than default.  Useful if you use :test to ignore email in dev mode.
