### PR TITLE
fix set_delivery_method - not getting applied after Mail is created

### DIFF
--- a/app/controllers/email_preview_controller.rb
+++ b/app/controllers/email_preview_controller.rb
@@ -3,18 +3,12 @@ class EmailPreviewController < ApplicationController
   layout false
 
   before_filter :enforce_allowed_environments
+  around_filter :set_delivery_method, :only => :deliver
   before_filter :build_email, :only => [:show, :deliver, :details, :preview]
 
   def deliver
     @mail.to params[:to]
-    
-    previous_delivery_method = ActionMailer::Base.delivery_method
-    begin
-      ActionMailer::Base.delivery_method = EmailPreview.delivery_method if EmailPreview.delivery_method
-      @mail.deliver
-    ensure
-      ActionMailer::Base.delivery_method = previous_delivery_method
-    end
+    @mail.deliver
     redirect_to details_email_preview_path(params[:id])
   end
   def preview
@@ -33,5 +27,12 @@ class EmailPreviewController < ApplicationController
   def build_email
     @mail = EmailPreview.preview params[:id]
     @parts = @mail.multipart? ? @mail.parts : [@mail]
+  end
+  def set_delivery_method
+    previous_delivery_method = ActionMailer::Base.delivery_method
+    ActionMailer::Base.delivery_method = EmailPreview.delivery_method if EmailPreview.delivery_method
+    yield
+  ensure
+    ActionMailer::Base.delivery_method = previous_delivery_method
   end
 end


### PR DESCRIPTION
The Mail's delivery_method gets set when the Mail is created.  Doesn't apply any more if you change it after the fact.
