### PR TITLE
removed unloadable from controller

### DIFF
--- a/app/controllers/email_preview_controller.rb
+++ b/app/controllers/email_preview_controller.rb
@@ -1,5 +1,4 @@
 class EmailPreviewController < ApplicationController
-  unloadable
   layout false
 
   before_filter :enforce_allowed_environments


### PR DESCRIPTION
Unloadable causes issues while running in Rails 4.

Removed unloadable from the controller because of a RuntimeError (Circular dependency detected while autoloading constant EmailPreviewController), which happens due to changes of unloadable from Rails 3 to Rails 4. The problem is discussed here: https://github.com/thoughtbot/clearance/issues/276.  Let me know if this solution doesn't work for you!
