### PR TITLE
Add ability to pass params to email fixtures

### DIFF
--- a/app/controllers/email_preview_controller.rb
+++ b/app/controllers/email_preview_controller.rb
@@ -25,7 +25,7 @@ class EmailPreviewController < ApplicationController
     raise "'#{Rails.env}' is not in the supported list of environments from EmailPreview.allowed_environments: #{EmailPreview.allowed_environments.inspect}" unless EmailPreview.allowed_environments.include?(Rails.env)
   end
   def build_email
-    @mail = EmailPreview.preview params[:id]
+    @mail = EmailPreview.preview params[:id], params[:extra]
     @parts = @mail.multipart? ? @mail.parts : [@mail]
   end
   def set_delivery_method

--- a/app/views/email_preview/details.html.erb
+++ b/app/views/email_preview/details.html.erb
@@ -26,11 +26,17 @@
     padding: 1px;
   }
 
-  .deliver_form {
+  .deliver_form, .extra_params_form {
     margin-bottom: 0;
     float: right;
   }
-  .deliver_form input {
+
+  .extra_params_form{
+    clear: right;
+    margin-top: 10px;
+  }
+
+  .deliver_form input, .extra_params_form input {
     width: 250px;
   }
 
@@ -41,10 +47,26 @@
     margin-left: 10px
   }
 </style>
+
+<script type="text/javascript">
+  function set_preview_url () {
+    var frame, url;
+    frame = parent.frames['preview'].document;
+    url   = frame.location.origin + frame.location.pathname;
+    document.getElementsByClassName("extra_params_form")[0].action = url;
+    return false;
+  }
+</script>
 <%= form_tag deliver_email_preview_path(params[:id]), :class => 'deliver_form' do %>
   <%= text_field_tag :to, session[:email_preview_to], :placeholder => 'Send this email to me@yourcompany.com' %>
   <button type="submit">Deliver Preview</button>
 <% end %>
+
+<%= form_tag preview_email_preview_path(params[:id]), :class => 'extra_params_form', :target => "preview", :method => :get do %>
+  <%= text_field_tag :extra, nil, :placeholder => 'Extra params (ie. foo=bar&day=monday' %>
+  <button type="submit" onclick="set_preview_url();">Add Params</button>
+<% end %>
+
 <h2>Headers</h2>
 <div class="headers">
 <% @mail.header_fields.each do |header| %>

--- a/email_preview.gemspec
+++ b/email_preview.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<rails>, ['>= 3.0'])
   s.add_development_dependency(%q<shoulda>, [">= 0"])
   s.add_development_dependency(%q<rake>, ["0.9.2"])
-  s.add_development_dependency(%q<sqlite3>, ["1.3.4"])
+  s.add_development_dependency(%q<sqlite3>, ["~> 1.3.8"])
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/email_preview.rb
+++ b/lib/email_preview.rb
@@ -18,9 +18,9 @@ module EmailPreview
     def categories
       self.registry.collect {|f| f.category }.uniq
     end
-    def preview(key)
+    def preview(key, params = {})
       EmailPreview.before_preview_hook.call
-      self[key].preview
+      self[key].preview(params)
     end
     def [](key)
       self.registry[key.to_i]

--- a/lib/email_preview/fixture.rb
+++ b/lib/email_preview/fixture.rb
@@ -8,19 +8,32 @@ module EmailPreview
       self.description = options[:description] || description.to_s
       self.callback = block
     end
-    def preview
-      self.callback.call
+    
+    def preview(params)
+      case self.callback.arity
+      when 0
+        self.callback.call
+      else
+        self.callback.call(parse_params(params))
+      end
     end
-    def preview_with_transaction
-      return preview_without_transaction unless EmailPreview.transactional?
+
+    def preview_with_transaction(params)
+      return preview_without_transaction(params) unless EmailPreview.transactional?
       mail = nil
       ActiveRecord::Base.transaction do
-        mail = preview_without_transaction
+        mail = preview_without_transaction(params)
         raise ActiveRecord::Rollback, "EmailPreview rollback"
       end
       mail
     end
     alias_method_chain :preview, :transaction
+
+    protected
+
+    def parse_params(params)
+      Rack::Utils.parse_nested_query(params).symbolize_keys
+    end
   end
 
 end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -17,9 +17,3 @@ test:
   database: db/test.sqlite3
   pool: 5
   timeout: 5000
-
-production:
-  adapter: sqlite3
-  database: db/production.sqlite3
-  pool: 5
-  timeout: 5000

--- a/test/dummy/config/initializers/email_preview.rb
+++ b/test/dummy/config/initializers/email_preview.rb
@@ -23,3 +23,12 @@ EmailPreview.register 'multipart email (html + text)' do
     end
   end
 end
+
+
+EmailPreview.register 'email with params' do |params|
+  Mail.new do
+    to params[:email]
+    from 'me@foo.com'
+    body "check this out, #{params[:name]}"
+  end
+end

--- a/test/test_email_preview.rb
+++ b/test/test_email_preview.rb
@@ -3,7 +3,32 @@ require 'helper'
 class TestEmailPreview < Test::Unit::TestCase
   context "with fixtures defined in test/dummy/config/initializers/email_preview.rb" do
     should "have entries in registry" do
-      assert_equal 2, EmailPreview.registry.length
+      assert_equal 3, EmailPreview.registry.length
+    end
+  end
+
+  context "with additional params" do
+    setup do
+      EmailPreview.transactional = false
+    end
+
+    should "not affect fixtures that don't take params" do
+      assert_nothing_raised(ArgumentError) { EmailPreview.preview(0) }
+    end
+
+    should "pass hash to email fixture" do
+      mail = EmailPreview.preview 2, "email=test@test.com"
+      assert_equal ["test@test.com"], mail.to
+    end
+  end
+end
+
+class EmailPreviewControllerTest < ActionController::TestCase
+  context "passing params to preview" do
+    should "accept attributes from form" do
+      get :preview, :id => 2, :extra => "email=test@test.com&name=John+Appleseed"
+      mail = assigns(:mail)
+      assert_match(/John\sAppleseed/, mail.body.to_s)
     end
   end
 end


### PR DESCRIPTION
I found the need to pass additional params when previewing emails like a specific email address or a user id, etc. This adds that functionality.
