### PR TITLE
Disable delivery methods even for preview action

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ EmailPreview.register 'multipart email (html + text)' do
 end
 
 # Rails ActionMailer Example
-# each execution is wrapped with a transaction and 
+# each execution is wrapped with a transaction and
 # rolled back after completed so there are no side-effects
 EmailPreview.register 'Rails ActionMailer User activation email' do
   u = User.create :email => 'foo@example.com'
@@ -75,7 +75,7 @@ end
 
 ### (optional) expose to production environment
 
-By default the email_preview feature is only available in development mode.  
+By default the email_preview feature is only available in development mode.
 To make it available to other environments use:
 
 ```ruby
@@ -95,7 +95,7 @@ EmailPreview.delivery_method = :smtp # or :sendmail, etc
 ActionMailer::Base.smtp_settings = {:port => 12345} # additional configuration is optional
 ```
 
-## Contributing 
+## Contributing
 
 * Fork the project
 * Fix the issue
@@ -103,6 +103,10 @@ ActionMailer::Base.smtp_settings = {:port => 12345} # additional configuration i
 * Submit pull request on github
 
 See CONTRIBUTORS.txt for list of project contributors
+
+### Testing
+
+     bundle exec rake test
 
 ## Copyright
 

--- a/app/controllers/email_preview_controller.rb
+++ b/app/controllers/email_preview_controller.rb
@@ -11,7 +11,6 @@ class EmailPreviewController < ApplicationController
     @mail.respond_to?(:deliver_now) ? @mail.deliver_now : @mail.deliver
     redirect_to details_email_preview_path(params[:id])
   end
-
   def preview
     @part = if request.format == 'html'
       @parts.detect {|p| p.content_type && p.content_type.include?('text/html') }
@@ -21,30 +20,19 @@ class EmailPreviewController < ApplicationController
     @part ||= @parts.first
     render :text => @part.body.to_s
   end
-
   private
-
   def enforce_allowed_environments
     raise "'#{Rails.env}' is not in the supported list of environments from EmailPreview.allowed_environments: #{EmailPreview.allowed_environments.inspect}" unless EmailPreview.allowed_environments.include?(Rails.env)
   end
-
   def build_email
-    execute_with_delivery do
-      @mail = EmailPreview.preview params[:id]
-      @parts = @mail.multipart? ? @mail.parts : [@mail]
-    end
+    @mail = EmailPreview.preview params[:id]
+    @parts = @mail.multipart? ? @mail.parts : [@mail]
   end
-
   def set_delivery_method
-    execute_with_delivery { yield }
-  end
-
-  def execute_with_delivery
     previous_delivery_method = ActionMailer::Base.delivery_method
     ActionMailer::Base.delivery_method = EmailPreview.delivery_method if EmailPreview.delivery_method
     yield
   ensure
     ActionMailer::Base.delivery_method = previous_delivery_method
   end
-
 end

--- a/app/controllers/email_preview_controller.rb
+++ b/app/controllers/email_preview_controller.rb
@@ -11,6 +11,7 @@ class EmailPreviewController < ApplicationController
     @mail.respond_to?(:deliver_now) ? @mail.deliver_now : @mail.deliver
     redirect_to details_email_preview_path(params[:id])
   end
+
   def preview
     @part = if request.format == 'html'
       @parts.detect {|p| p.content_type && p.content_type.include?('text/html') }
@@ -20,19 +21,30 @@ class EmailPreviewController < ApplicationController
     @part ||= @parts.first
     render :text => @part.body.to_s
   end
+
   private
+
   def enforce_allowed_environments
     raise "'#{Rails.env}' is not in the supported list of environments from EmailPreview.allowed_environments: #{EmailPreview.allowed_environments.inspect}" unless EmailPreview.allowed_environments.include?(Rails.env)
   end
+
   def build_email
-    @mail = EmailPreview.preview params[:id]
-    @parts = @mail.multipart? ? @mail.parts : [@mail]
+    execute_with_delivery do
+      @mail = EmailPreview.preview params[:id]
+      @parts = @mail.multipart? ? @mail.parts : [@mail]
+    end
   end
+
   def set_delivery_method
+    execute_with_delivery { yield }
+  end
+
+  def execute_with_delivery
     previous_delivery_method = ActionMailer::Base.delivery_method
     ActionMailer::Base.delivery_method = EmailPreview.delivery_method if EmailPreview.delivery_method
     yield
   ensure
     ActionMailer::Base.delivery_method = previous_delivery_method
   end
+
 end

--- a/email_preview.gemspec
+++ b/email_preview.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<rails>, ['>= 3.0'])
   s.add_development_dependency(%q<shoulda>, [">= 0"])
   s.add_development_dependency(%q<rake>, ["0.9.2"])
-  s.add_development_dependency(%q<sqlite3>, ["1.3.4"])
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "rails/test_unit/railtie"
+require "sprockets/railtie"
 
 Bundler.require
 require "email_preview"

--- a/test/dummy/config/initializers/wrap_parameters.rb
+++ b/test/dummy/config/initializers/wrap_parameters.rb
@@ -7,8 +7,3 @@
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters :format => [:json]
 end
-
-# Disable root element in JSON by default.
-ActiveSupport.on_load(:active_record) do
-  self.include_root_in_json = false
-end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
+require 'test/unit'
 require 'shoulda'
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
I'm using letter_opener gem to inspect email locally at the time when they are sent. However, I noticed that using email_preview with letter_opener causes a problem - when I click to preview an email in EmailPreview admin, emails are generated and opened in the browser. This is a PR attempting to fix this situation. 

Please let me know if you have any thoughts about this
Thanks
