### PR TITLE
Make /email_preview url work if there is catch all route in application

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.draw do
+Rails.application.routes.prepend do
   resources :email_preview, :controller => 'email_preview', :only => [:index, :show] do
     collection do
       get :navigation


### PR DESCRIPTION
If you have something like that in your routes

match '/:permalink' => 'pages#show'

you can't access /email_preview
